### PR TITLE
Added minimal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
-# pretty-env-logger
+# pretty-env-logger [![Crates.io](https://img.shields.io/crates/v/pretty_env_logger.svg)](https://crates.io/crates/pretty_env_logger) [![Crates.io](https://img.shields.io/crates/l/pretty_env_logger.svg)](https://crates.io/crates/pretty_env_logger)
 
-License: MIT or Apache-2.0
+A simple logger build on top off [env_logger](https://docs.rs/env_logger).
+It is configured via an environment variable and writes to standard
+error with nice colored output for log levels.
+
+- [Documentation](https://docs.rs/pretty_env_logger/)
+
+## Usage
+```rust
+extern crate pretty_env_logger;
+#[macro_use] extern crate log;
+
+fn main() {
+    pretty_env_logger::init().unwrap();
+    info!("such information");
+    warn!("o_O");
+    error!("much error");
+}
+```
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,26 @@
+#![deny(warnings)]
+#![deny(missing_docs)]
+
+//! A logger configured via an environment variable which writes to standard
+//! error with nice colored output for log levels.
+//!
+//! ## Example
+//!
+//! ```
+//! extern crate pretty_env_logger;
+//! #[macro_use] extern crate log;
+//!
+//! fn main() {
+//!     pretty_env_logger::init().unwrap();
+//!
+//!     trace!("a trace example");
+//!     debug!("deboogging");
+//!     info!("such information");
+//!     warn!("o_O");
+//!     error!("boom");
+//! }
+//! ```
+
 extern crate ansi_term;
 extern crate env_logger;
 extern crate log;
@@ -24,6 +47,16 @@ impl fmt::Display for Level {
 }
 
 static MAX_MODULE_WIDTH: AtomicUsize = ATOMIC_USIZE_INIT;
+
+/// Initializes the global logger with a pretty env logger.
+///
+/// This should be called early in the execution of a Rust program, and the
+/// global logger may only be initialized once. Future initialization attempts
+/// will return an error.
+///
+/// # Errors
+///
+/// This function fails to set the global logger if one has already been set.
 
 pub fn init() -> Result<(), log::SetLoggerError> {
     let mut builder = LogBuilder::new();


### PR DESCRIPTION
fixes https://github.com/seanmonstar/pretty-env-logger/issues/2

Unfortunately I did not know how to add colored text example within rustdoc and README.md without embedding image. 