### PR TITLE
formatted_builder cannot error

### DIFF
--- a/examples/with_builder_1.rs
+++ b/examples/with_builder_1.rs
@@ -13,7 +13,7 @@ mod one {
 
 fn main() {
 
-    pretty_env_logger::formatted_builder().unwrap()
+    pretty_env_logger::formatted_builder()
         //let's just set some random stuff.. for more see
         //https://docs.rs/env_logger/0.5.0-rc.1/env_logger/struct.Builder.html
         .target(Target::Stdout)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub fn init_custom_env(environment_variable_name: &str) {
 ///
 /// This function fails to set the global logger if one has already been set.
 pub fn try_init_custom_env(environment_variable_name: &str) -> Result<(), log::SetLoggerError> {
-    let mut builder = formatted_builder()?;
+    let mut builder = formatted_builder();
 
     if let Ok(s) = ::std::env::var(environment_variable_name) {
         builder.parse(&s);
@@ -110,17 +110,9 @@ pub fn try_init_custom_env(environment_variable_name: &str) -> Result<(), log::S
 /// Returns a `env_logger::Builder` for further customization.
 ///
 /// This method will return a colored and formatted) `env_logger::Builder`
-/// for further customization. Tefer to env_logger::Build crate documentation
+/// for further customization. Defer to env_logger::Build crate documentation
 /// for further details and usage.
-///
-/// This should be called early in the execution of a Rust program, and the
-/// global logger may only be initialized once. Future initialization attempts
-/// will return an error.
-///
-/// # Errors
-///
-/// This function fails to set the global logger if one has already been set.
-pub fn formatted_builder() -> Result<Builder, log::SetLoggerError> {
+pub fn formatted_builder() -> Builder {
     let mut builder = Builder::new();
 
     builder.format(|f, record| {
@@ -143,5 +135,5 @@ pub fn formatted_builder() -> Result<Builder, log::SetLoggerError> {
         }
     });
 
-    Ok(builder)
+    builder
 }


### PR DESCRIPTION
`formatted_builder` cannot error; it does not call anything which returns an error. The documentation looks like a copy-paste error.

This will be an incompatible public API change, which might not be wanted. If not, I still suggest fixing the documentation, perhaps to:

> This function fails only if there's a problem constructing the builder. Setting the logger is not attempted.

The function signature is pretty useless anyway, even given future errors coming into existence, as it's unlikely the builder would ever return a `SetLoggerError`.