### PR TITLE
timestamps with milliseconds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ include = [
 ]
 
 [dependencies]
-env_logger = "0.6"
+env_logger = "0.6.2"
 log = "0.4"
 chrono = "0.4.4"

--- a/examples/with_builder_1.rs
+++ b/examples/with_builder_1.rs
@@ -17,7 +17,7 @@ fn main() {
         //let's just set some random stuff.. for more see
         //https://docs.rs/env_logger/0.5.0-rc.1/env_logger/struct.Builder.html
         .target(Target::Stdout)
-        .parse("with_builder_1=trace")
+        .parse_filters("with_builder_1=trace")
         .init();
 
     info!("such information");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ extern crate env_logger;
 extern crate log;
 extern crate chrono;
 
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use chrono::Local;
 use env_logger::{fmt::{Color, Style, StyledValue}, Builder};
@@ -41,7 +41,7 @@ fn colored_level<'a>(style: &'a mut Style, level: Level) -> StyledValue<'a, &'st
     }
 }
 
-static MAX_MODULE_WIDTH: AtomicUsize = ATOMIC_USIZE_INIT;
+static MAX_MODULE_WIDTH: AtomicUsize = AtomicUsize::new(0);
 
 /// Initializes the global logger with a pretty env logger.
 ///
@@ -123,7 +123,7 @@ pub fn try_init_custom_env(environment_variable_name: &str) -> Result<(), log::S
     let mut builder = formatted_builder();
 
     if let Ok(s) = ::std::env::var(environment_variable_name) {
-        builder.parse(&s);
+        builder.parse_filters(&s);
     }
 
     builder.try_init()
@@ -142,7 +142,7 @@ pub fn try_init_timed_custom_env(environment_variable_name: &str) -> Result<(), 
     let mut builder = formatted_timed_builder();
 
     if let Ok(s) = ::std::env::var(environment_variable_name) {
-        builder.parse(&s);
+        builder.parse_filters(&s);
     }
 
     builder.try_init()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub fn formatted_timed_builder() -> Builder {
         writeln!(
             f,
             " {} {} {} > {}",
-            Local::now().format("%Y-%m-%d %H:%M:%S"),
+            Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
             level,
             target,
             record.args(),


### PR DESCRIPTION
I filed https://github.com/sebasmagri/env_logger/issues/122 a few minutes ago, then I noticed that pretty_env_logger supports timestamps and that adding milliseconds would be easy over here. This is obviously an opinionated pull request, submitted humbly. :)

I also replaced the space with `T`. I like it that way because then the timestamp is one field if you're parsing with awk or something like that, and it's iso8601-preferred. But I'm willing to revert that part of the change if it's a deal breaker.