### PR TITLE
fix with_builder_1 example

### DIFF
--- a/examples/with_builder_1.rs
+++ b/examples/with_builder_1.rs
@@ -13,7 +13,7 @@ mod one {
 
 fn main() {
 
-    pretty_env_logger::formatted_builder().unwrap()
+    pretty_env_logger::formatted_builder()
         //let's just set some random stuff.. for more see
         //https://docs.rs/env_logger/0.5.0-rc.1/env_logger/struct.Builder.html
         .target(Target::Stdout)


### PR DESCRIPTION
Builder isn't a result since 8782240d337c9fe18dc825e4b1853f9dd3c00574

This should fix CI builds. 
Tested on Travis and AppVeyor.