### PR TITLE
Make env_logger dependency public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! }
 //! ```
 
-extern crate env_logger;
+pub extern crate env_logger;
 extern crate log;
 extern crate chrono;
 


### PR DESCRIPTION
This way we can use its constants without having to also specify a matching dependency of `env_logger` manually. Example use case:

```rust
pretty_env_logger::formatted_timed_builder()
  .write_style(pretty_env_logger::env_logger::WriteStyle::Always)`
```