### PR TITLE
fixes RUST_LOG env goof in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ fn main() {
 Then run your app with the environmental variable set:
 
 ```
-RUST_LOG=myapp=trace cargo run
+RUST_LOG=trace cargo run
 ```
 
 ## License


### PR DESCRIPTION
`RUST_LOG=myapp=trace` will result in no logs being printed. This updates the README, removing the app's name.