### PR TITLE
Update Cargo.toml instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependency to your `Cargo.toml`:
 ```toml
 [dependencies]
 log = "0.4"
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 ```
 
 Add some usage to your application:


### PR DESCRIPTION
Looks like the latest release is [v0.4.0](https://crates.io/crates/pretty_env_logger/0.4.0). This PR just updates the `Cargo.toml` suggestion in `README.md` to match.