### PR TITLE
add (enabled by default) regex feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ include = [
   "src/**/*"
 ]
 
+[features]
+default = ["regex"]
+regex = ["env_logger/regex"]
+
 [dependencies]
-env_logger = "0.7.0"
+env_logger = { version = "0.7.0", default-features = false, features = ["termcolor", "humantime", "atty"] }
 log = "0.4"


### PR DESCRIPTION
see #28.
I don't think disabling color is that useful because at that point you can just use `env_logger` directly, so I just added a feature for `regex`.