### PR TITLE
Re-export env_logger's optional features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,15 @@ include = [
 ]
 
 [dependencies]
-env_logger = "0.7.0"
 log = "0.4"
+
+[dependencies.env_logger]
+version = "0.7.0"
+default-features = false
+features = ["termcolor"]
+
+[features]
+default = ["atty", "humantime", "regex"]
+atty = ["env_logger/atty"]
+humantime = ["env_logger/humantime"]
+regex = ["env_logger/regex"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub fn init() {
 /// # Panics
 ///
 /// This function fails to set the global logger if one has already been set.
+#[cfg(feature = "humantime")]
 pub fn init_timed() {
     try_init_timed().unwrap();
 }
@@ -96,6 +97,7 @@ pub fn try_init() -> Result<(), log::SetLoggerError> {
 /// # Errors
 ///
 /// This function fails to set the global logger if one has already been set.
+#[cfg(feature = "humantime")]
 pub fn try_init_timed() -> Result<(), log::SetLoggerError> {
     try_init_timed_custom_env("RUST_LOG")
 }
@@ -141,6 +143,7 @@ pub fn try_init_custom_env(environment_variable_name: &str) -> Result<(), log::S
 /// # Errors
 ///
 /// This function fails to set the global logger if one has already been set.
+#[cfg(feature = "humantime")]
 pub fn try_init_timed_custom_env(environment_variable_name: &str) -> Result<(), log::SetLoggerError> {
     let mut builder = formatted_timed_builder();
 
@@ -191,6 +194,7 @@ pub fn formatted_builder() -> Builder {
 /// This method will return a colored and time formatted `env_logger::Builder`
 /// for further customization. Refer to env_logger::Build crate documentation
 /// for further details and usage.
+#[cfg(feature = "humantime")]
 pub fn formatted_timed_builder() -> Builder {
     let mut builder = Builder::new();
 


### PR DESCRIPTION
Re-export the `atty`, `humantime` and `regex` features. Some time-related features are disabled without `humantime`.

I did not make `termcolor` optional because it seemed too interleaved with pretty_env_logger's code, and because I'm not sure it would still justify the name without this. (-:

The biggest gain is eliminating the the `regex` feature/dependency, which I noticed was adding 1.1MB to my stripped release build `.so` file.

The default behavior remains the same with everything enabled.