### PR TITLE
Update env logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ include = [
 ]
 
 [dependencies]
-env_logger = "0.7.0"
+env_logger = "0.9"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pretty_env_logger"
-version = "0.4.1" # don't forget to update html_root_url
+version = "0.4.0" # don't forget to update html_root_url
 description = "a visually pretty env_logger"
 repository = "https://github.com/seanmonstar/pretty-env-logger"
 authors = ["Sean McArthur <sean@seanmonstar>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pretty_env_logger"
-version = "0.4.0" # don't forget to update html_root_url
+version = "0.4.1" # don't forget to update html_root_url
 description = "a visually pretty env_logger"
 repository = "https://github.com/seanmonstar/pretty-env-logger"
 authors = ["Sean McArthur <sean@seanmonstar>"]

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,5 +1,6 @@
 extern crate pretty_env_logger;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 mod nested {
     pub fn deep() {

--- a/examples/with_builder_1.rs
+++ b/examples/with_builder_1.rs
@@ -1,6 +1,7 @@
-extern crate pretty_env_logger;
 extern crate env_logger;
-#[macro_use] extern crate log;
+extern crate pretty_env_logger;
+#[macro_use]
+extern crate log;
 
 use env_logger::Target;
 
@@ -12,7 +13,6 @@ mod one {
 }
 
 fn main() {
-
     pretty_env_logger::formatted_builder()
         //let's just set some random stuff.. for more see
         //https://docs.rs/env_logger/0.5.0-rc.1/env_logger/struct.Builder.html

--- a/examples/with_custom_env.rs
+++ b/examples/with_custom_env.rs
@@ -1,5 +1,6 @@
 extern crate pretty_env_logger;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 use std::env;
 
@@ -11,7 +12,6 @@ mod one {
 }
 
 fn main() {
-
     env::set_var("RUST_APP_LOG", "trace");
 
     pretty_env_logger::init_custom_env("RUST_APP_LOG");

--- a/examples/with_try_init.rs
+++ b/examples/with_try_init.rs
@@ -1,5 +1,6 @@
 extern crate pretty_env_logger;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 mod one {
     pub fn deep() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/pretty_env_logger/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/pretty_env_logger/0.4.1")]
 
 //! A logger configured via an environment variable which writes to standard
 //! error with nice colored output for log levels.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,11 @@ extern crate log;
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use env_logger::{fmt::{Color, Style, StyledValue}, Builder};
+use env_logger::{
+    fmt::{Color, Style, StyledValue},
+    Builder,
+};
 use log::Level;
-
 
 /// Initializes the global logger with a pretty env logger.
 ///
@@ -141,7 +143,9 @@ pub fn try_init_custom_env(environment_variable_name: &str) -> Result<(), log::S
 /// # Errors
 ///
 /// This function fails to set the global logger if one has already been set.
-pub fn try_init_timed_custom_env(environment_variable_name: &str) -> Result<(), log::SetLoggerError> {
+pub fn try_init_timed_custom_env(
+    environment_variable_name: &str,
+) -> Result<(), log::SetLoggerError> {
     let mut builder = formatted_timed_builder();
 
     if let Ok(s) = ::std::env::var(environment_variable_name) {
@@ -174,13 +178,7 @@ pub fn formatted_builder() -> Builder {
             width: max_width,
         });
 
-        writeln!(
-            f,
-            " {} {} > {}",
-            level,
-            target,
-            record.args(),
-        )
+        writeln!(f, " {} {} > {}", level, target, record.args(),)
     });
 
     builder
@@ -210,14 +208,7 @@ pub fn formatted_timed_builder() -> Builder {
 
         let time = f.timestamp_millis();
 
-        writeln!(
-            f,
-            " {} {} {} > {}",
-            time,
-            level,
-            target,
-            record.args(),
-        )
+        writeln!(f, " {} {} {} > {}", time, level, target, record.args(),)
     });
 
     builder
@@ -230,7 +221,7 @@ struct Padded<T> {
 
 impl<T: fmt::Display> fmt::Display for Padded<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{: <width$}", self.value, width=self.width)
+        write!(f, "{: <width$}", self.value, width = self.width)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/pretty_env_logger/0.4.1")]
+#![doc(html_root_url = "https://docs.rs/pretty_env_logger/0.4.0")]
 
 //! A logger configured via an environment variable which writes to standard
 //! error with nice colored output for log levels.


### PR DESCRIPTION
This PR updates `env-logger` to version `0.9` since it's been out for a few months now (and 0.8 even longer).

The only upstream breaking change is the MSRV being [increased to `1.41`](https://github.com/env-logger-rs/env_logger/releases/tag/v0.8.0). However, while I don't see a MSRV for `pretty_env_logger`, its doubtful it will break any users as Debian stable ships a minimum of 1.41.1 and the majority of users are on newer compiler versions.

Closes https://github.com/seanmonstar/pretty-env-logger/issues/50