### PR TITLE
env_logger: create builder with from_default_env

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub fn try_init_timed_custom_env(
 /// for further customization. Refer to env_logger::Build crate documentation
 /// for further details and usage.
 pub fn formatted_builder() -> Builder {
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_default_env();
 
     builder.format(|f, record| {
         use std::io::Write;
@@ -190,7 +190,7 @@ pub fn formatted_builder() -> Builder {
 /// for further customization. Refer to env_logger::Build crate documentation
 /// for further details and usage.
 pub fn formatted_timed_builder() -> Builder {
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_default_env();
 
     builder.format(|f, record| {
         use std::io::Write;


### PR DESCRIPTION
This allows `RUST_LOG` to take effect but still be overridden by later customization.

This addresses #43.