### PR TITLE
Update env_logger to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ include = [
 ]
 
 [dependencies]
-env_logger = "0.10"
+env_logger = "0.11"
 log = "0.4"


### PR DESCRIPTION
This PR bumps the env_logger dependency to v0.11. As noted in the commit message:

> env_logger 0.11 removed the API around which this library is written and offloaded its functionality to the anstyle crate, which is re-exported as env_logger::fmt::style. anstyle's API is very different than v0.10's: anstyle just provides ANSI escape codes which must then be used in format strings. Opening escape codes are printed with "{}" and closing escape codes are printed with "{:#}". `fn colored_level` must be re-written from scratch (and nicely enough can be marked as const).

Closes: #59 